### PR TITLE
Fixes exception thrown when not using user acl

### DIFF
--- a/DependencyInjection/Factory/AclAwareAmazonS3AdapterFactory.php
+++ b/DependencyInjection/Factory/AclAwareAmazonS3AdapterFactory.php
@@ -61,7 +61,7 @@ class AclAwareAmazonS3AdapterFactory implements AdapterFactoryInterface
         $builder
             ->validate()
                 ->always(function($v) {
-                    if (isset($v['acl']) && isset($v['users'])) {
+                    if (!empty($v['acl']) && !empty($v['users'])) {
                         throw new \Exception('"acl", and "users" cannot be set both at the same time.');
                     }
 
@@ -77,7 +77,7 @@ class AclAwareAmazonS3AdapterFactory implements AdapterFactoryInterface
                     ->prototype('array')
                         ->validate()
                             ->always(function($v) {
-                                if (isset($v['group']) === isset($v['id'])) {
+                                if (!empty($v['group']) === !empty($v['id'])) {
                                     throw new \Exception('Either "group", or "id" must be set.');
                                 }
 


### PR DESCRIPTION
I posted the error on the original pull request.  Basically it thinks user is set when it really isn't saying user and ACL can't be used together.

This is a simple fix.
