### PR TITLE
show correct message when 0 keys are available

### DIFF
--- a/Command/FilesystemKeysCommand.php
+++ b/Command/FilesystemKeysCommand.php
@@ -61,14 +61,14 @@ EOT
 
         $count = count($keys);
 
-        $output->writeln(
-            sprintf(
+        $message = $count ? sprintf(
                 'Bellow %s the <info>%s key%s</info> that where found:',
                 $count > 1 ? 'are' : 'is',
                 $count,
                 $count > 1 ? 's': ''
-            )
-        );
+            ) : "<info>0 keys</info> were found.";
+
+        $output->writeln($message);
 
         $output->setDecorated(true);
         foreach ($keys as $key) {


### PR DESCRIPTION
Fixes the ticket: #8

```
php app/console gaufrette:filesystem:keys
0 keys were found.
```
