### PR TITLE
Fix undefined FTP_ASCII constant issue when running with php CLI

### DIFF
--- a/DependencyInjection/Factory/FtpAdapterFactory.php
+++ b/DependencyInjection/Factory/FtpAdapterFactory.php
@@ -1,14 +1,14 @@
 <?php
-// PHPClient - Workaround otherwise 'app/console' execution failed...
-if (!defined('FTP_ASCII')) { define('FTP_ASCII', 1); }
-if (!defined('FTP_BINARY')) { define('FTP_BINARY', 2); }
-
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
+
+// PHPClient - Workaround otherwise 'app/console' execution failed...
+if (!defined('FTP_ASCII')) { define('FTP_ASCII', 1); }
+if (!defined('FTP_BINARY')) { define('FTP_BINARY', 2); }
 
 /**
  * Ftp Adapter Factory


### PR DESCRIPTION
After installation of the GaufretteBundle my vendor script failed with following error msg:

[ErrorException]

Notice: Use of undefined constant FTP_ASCII - assumed 'FTP_ASCII' in .../vendor/bundles/Knp/Bundle/GaufretteBundle/DependencyInjection/Factory/FtpAdapterFactory.php line 57

To solve this issue I've add the following line at top of FtpAdapterFactory:

if (!defined('FTP_ASCII')) { define('FTP_ASCII', 1); }

This solves the issue for my case.
