### PR TITLE
If ftp extension of php miss, it'll not throw exception

### DIFF
--- a/DependencyInjection/Factory/FtpAdapterFactory.php
+++ b/DependencyInjection/Factory/FtpAdapterFactory.php
@@ -53,7 +53,7 @@ class FtpAdapterFactory implements AdapterFactoryInterface
                 ->booleanNode('passive')->defaultFalse()->end()
                 ->booleanNode('create')->defaultFalse()->end()
                 ->scalarNode('mode')
-                    ->defaultValue(FTP_ASCII)
+                    ->defaultValue(defined('FTP_ASCII') ? FTP_ASCII : null)
                     ->beforeNormalization()
                     ->ifString()
                     ->then(function($v) { return constant($v); })


### PR DESCRIPTION
I actually don't need `ftp` extension 
