### PR TITLE
fix StreamWrapper not containing filesystems

### DIFF
--- a/FilesystemMap.php
+++ b/FilesystemMap.php
@@ -6,7 +6,7 @@ namespace Knp\Bundle\GaufretteBundle;
  * Holds references to all declared filesystems
  * and allows to access them through their name
  */
-class FilesystemMap
+class FilesystemMap implements \IteratorAggregate
 {
     /**
      * Map of filesystems indexed by their name
@@ -26,9 +26,13 @@ class FilesystemMap
     }
 
     /**
+     * Retrieves a filesystem by its name.
+     *
      * @param string $name name of a filesystem
+     *
+     * @return \Gaufrette\Filesystem
+     *
      * @throw \InvalidArgumentException if the filesystem does not exist
-     * @return Filesystem
      */
     public function get($name)
     {
@@ -37,5 +41,10 @@ class FilesystemMap
         }
 
         return $this->map[$name];
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->map);
     }
 }

--- a/KnpGaufretteBundle.php
+++ b/KnpGaufretteBundle.php
@@ -27,12 +27,19 @@ class KnpGaufretteBundle extends Bundle
 
         $fileSystems = $this->container->getParameter('knp_gaufrette.stream_wrapper.filesystems');
 
+        /*
+         * If there are no filesystems configured to be wrapped,
+         * all filesystems within the map will be wrapped.
+         */
         if (empty($fileSystems)) {
             $fileSystems = $this->container->get('knp_gaufrette.filesystem_map');
-        }
-
-        foreach ($fileSystems as $domain => $fileSystem) {
-            $wrapperFsMap->set($domain, $this->container->get('knp_gaufrette.filesystem_map')->get($fileSystem));
+            foreach ($fileSystems as $domain => $fileSystem) {
+                $wrapperFsMap->set($domain, $fileSystem);
+            }
+        } else {
+            foreach ($fileSystems as $domain => $fileSystem) {
+                $wrapperFsMap->set($domain, $this->container->get('knp_gaufrette.filesystem_map')->get($fileSystem));
+            }
         }
     }
 }

--- a/Tests/Functional/ConfigurationTest.php
+++ b/Tests/Functional/ConfigurationTest.php
@@ -113,10 +113,15 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('gaufrette', $container->getParameter('knp_gaufrette.stream_wrapper.protocol'));
 
         $wrapperFsMap = StreamWrapper::getFilesystemMap();
-        $fileSystems = $this->kernel->getContainer()->get('knp_gaufrette.filesystem_map');
 
-        foreach($fileSystems as $fs) {
-            $this->assertTrue($wrapperFsMap->has($fs));
+        $expectedDomains = array(
+            'foo',
+            'cache',
+            'ftp',
+        );
+
+        foreach ($expectedDomains as $eachExpectedDomain) {
+            $this->assertTrue($wrapperFsMap->has($eachExpectedDomain));
         }
     }
 


### PR DESCRIPTION
Adding `stream_wrapper: ~` to the configuration failed to add the filesystems.
