### PR TITLE
Bugfix: Acl Aware S3 factory could not set options

### DIFF
--- a/DependencyInjection/Factory/AclAwareAmazonS3AdapterFactory.php
+++ b/DependencyInjection/Factory/AclAwareAmazonS3AdapterFactory.php
@@ -14,7 +14,7 @@ class AclAwareAmazonS3AdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, $id, array $config)
     {
-        $container
+        $definition = $container
             ->setDefinition($id.'.delegate', new DefinitionDecorator('knp_gaufrette.adapter.amazon_s3'))
             ->addArgument(new Reference($config['amazon_s3_id']))
             ->addArgument($config['bucket_name'])


### PR DESCRIPTION
The $definition var was unset; this patch resolves that
