### PR TITLE
Allow AclAwareAmazonS3Adapter to have options set

### DIFF
--- a/DependencyInjection/Factory/AclAwareAmazonS3AdapterFactory.php
+++ b/DependencyInjection/Factory/AclAwareAmazonS3AdapterFactory.php
@@ -89,6 +89,15 @@ class AclAwareAmazonS3AdapterFactory implements AdapterFactoryInterface
                     ->end()
                 ->end()
                 ->booleanNode('create')->defaultFalse()->end()
+                ->arrayNode('options')
+                    ->children()
+                        ->booleanNode('create')
+                            ->defaultFalse()
+                        ->end()
+                        ->scalarNode('region')->end()
+                        ->scalarNode('directory')->end()
+                    ->end()
+                ->end()
             ->end()
         ;
     }


### PR DESCRIPTION
This PR fixes the following exception being thrown when you set the region for the acl aware S3 adapter:

> InvalidConfigurationException: Unrecognized options "options" under "knp_gaufrette.adapters.s3.acl_aware_amazon_s3"

See #40 and #42
