### PR TITLE
Allow AmazonsS3 adapter to have acl option

### DIFF
--- a/DependencyInjection/Factory/AmazonS3AdapterFactory.php
+++ b/DependencyInjection/Factory/AmazonS3AdapterFactory.php
@@ -51,6 +51,7 @@ class AmazonS3AdapterFactory implements AdapterFactoryInterface
                         ->end()
                         ->scalarNode('region')->end()
                         ->scalarNode('directory')->end()
+                        ->scalarNode('acl')->end()
                     ->end()
                 ->end()
             ->end()


### PR DESCRIPTION
Now, in the bundle is no posibility to add default acl value in config and uploaded file gets ACL_PUBLIC by default
