### PR TITLE
ObjectStore-method became objectStoreService-method in php-opencloud

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -620,7 +620,7 @@ services:
     opencloud.object_store:
         class: OpenCloud\ObjectStoreBase
         factory_service: opencloud.connection
-        factory_method: ObjectStore
+        factory_method: objectStoreService
         arguments:
           - 'cloudFiles' # Object storage type
           - 'DFW' # Object storage region


### PR DESCRIPTION
Fixes "call to undefined method OpenCloud\Rackspace::ObjectStore()" we were experiencing...

Thanks in advance for merging in this documentation-update!

Kind regards,
David