### PR TITLE
Update composer.json to provide support for symfony 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require":      {
-        "symfony/framework-bundle": "2.*",
+        "symfony/framework-bundle": "2.*|~3.0",
         "knplabs/gaufrette":        "~0.1.7|0.2.*@dev"
     },
     "require-dev": {
-        "symfony/yaml": "2.*",
-        "symfony/console": "2.*",
+        "symfony/yaml": "2.*|~3.0",
+        "symfony/console": "2.*|~3.0",
         "phpunit/phpunit": "~4.2"
     },
     "autoload":     {


### PR DESCRIPTION
Enabling Symfony 3 support. It looks like the code is prepared to accept the requirement of 3.0. Tests pass after a `composer require "symfony/symfony:3.0.*@dev"`