### PR TITLE
Added FTP utf8 mode flag to config.

### DIFF
--- a/DependencyInjection/Factory/FtpAdapterFactory.php
+++ b/DependencyInjection/Factory/FtpAdapterFactory.php
@@ -48,6 +48,7 @@ class FtpAdapterFactory implements AdapterFactoryInterface
                 ->booleanNode('passive')->defaultFalse()->end()
                 ->booleanNode('create')->defaultFalse()->end()
                 ->booleanNode('ssl')->defaultFalse()->end()
+                ->booleanNode('utf8')->defaultFalse()->end()
                 ->scalarNode('mode')
                     ->defaultValue(defined('FTP_ASCII') ? FTP_ASCII : null)
                     ->beforeNormalization()

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,15 @@
             "homepage": "https://github.com/knplabs/KnpGaufretteBundle/contributors"
         }
     ],
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/IWAtech/Gaufrette"
+		}
+	],
     "require":      {
         "symfony/framework-bundle": "~2.0|~3.0",
-        "knplabs/gaufrette":        "https://github.com/IWAtech/Gaufrette/archive/0.2.2.tar.gz"
+        "knplabs/gaufrette":        "dev-utf8-mode as dev-master"
     },
     "require-dev": {
         "symfony/yaml": "~2.0|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require":      {
         "symfony/framework-bundle": "~2.0|~3.0",
-        "knplabs/gaufrette":        "~0.1.7|~0.2"
+        "knplabs/gaufrette":        "https://github.com/IWAtech/Gaufrette/archive/0.2.2.tar.gz"
     },
     "require-dev": {
         "symfony/yaml": "~2.0|~3.0",


### PR DESCRIPTION
Since some FTP Servers support (and even require) UTF-8 for proper communication of non ASCII Filenames I added support for the corresponding flag in the configuration. There are no checks if the server supports it, I am assuming that if the user configures utf8 support, he has validated that his server supports utf8. We are using a forked version of Gaufrette in our Project.

https://tools.ietf.org/html/draft-ietf-ftpext-utf-8-option-00

https://github.com/KnpLabs/Gaufrette/pull/408
