### PR TITLE
Suggest to use official AWS client

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ This adapter requires the use of amazonwebservices/aws-sdk-for-php which can be 
 ```
     "require": {
         ...
-        "amazonwebservices/aws-sdk-for-php": "1.6.2"
+        "aws/aws-sdk-php": "1.6.2"
     },
 ```
 


### PR DESCRIPTION
Official package is `aws/aws-sdk-php`. Maybe newer version should be used as well?
