### PR TITLE
Mention ttl units in docs

### DIFF
--- a/Resources/docs/adapters/cache.md
+++ b/Resources/docs/adapters/cache.md
@@ -6,7 +6,7 @@ Adapter which allows you to cache other adapters
 
  * `source` The source adapter that must be cached *(required)*
  * `cache` The adapter used to cache the source *(required)*
- * `ttl` Time to live *(default 0)*
+ * `ttl` Time to live, in seconds *(default 0)*
  * `serializer` The adapter used to cache serializations *(default null)*
 
 ## Example


### PR DESCRIPTION
As far as I can tell, `ttl` is directly subtracted from time() in Gaufrette, which means it's in seconds. Good idea to document.