### PR TITLE
allows knplabs/gaufrette v0.3 too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require":      {
         "symfony/framework-bundle": "~2.0|~3.0",
-        "knplabs/gaufrette":        "~0.1.7|~0.2"
+        "knplabs/gaufrette":        "~0.1.7|~0.2|~0.3"
     },
     "require-dev": {
         "symfony/yaml": "~2.0|~3.0",


### PR DESCRIPTION
``knplabs/gaufrette`` v0.3 was just released, but is not allowed in composer.json.

Targetting this issue, isn't it more practical to release ``knplabs/gaufrette`` in version 1.0, so semantic-version would work?
Doing so, an update on gaufrette to e.g. 1.1 would also be matched by:

    "require": {
        "knplabs/gaufrette": "~1.0"
    }

So there wouldn't be a need to update the composer.json everytime a new (minor) version of gaufrette is released.