### PR TITLE
Adds timeout config to FtpAdapterConfiguration

### DIFF
--- a/DependencyInjection/Factory/FtpAdapterFactory.php
+++ b/DependencyInjection/Factory/FtpAdapterFactory.php
@@ -45,6 +45,7 @@ class FtpAdapterFactory implements AdapterFactoryInterface
                 ->scalarNode('port')->defaultValue(21)->end()
                 ->scalarNode('username')->defaultNull()->end()
                 ->scalarNode('password')->defaultNull()->end()
+                ->scalarNode('timeout')->defaultValue(90)->end()
                 ->booleanNode('passive')->defaultFalse()->end()
                 ->booleanNode('create')->defaultFalse()->end()
                 ->booleanNode('ssl')->defaultFalse()->end()


### PR DESCRIPTION
Since ``knplabs/gaufrette`` v0.3 it's possible to configure the connect-timeout while initiating a ftp-connection. See https://github.com/KnpLabs/Gaufrette/pull/444

For me, it would be convenient to allow setting this configuration in my bundle's configuration too :-)