### PR TITLE
Add missing dependencies + tweak travis conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,34 +4,24 @@ sudo: false
 
 dist: precise
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-
 cache:
   directories:
     - $HOME/.composer/cache
 
 matrix:
   include:
-    - php: 5.6
-      env: SYMFONY_VERSION='~2.3'
-    - php: 5.6
-      env: SYMFONY_VERSION='~2.8'
-    - php: 5.6
-      env: SYMFONY_VERSION='~3.0'
-    - php: 5.6
-      env: SYMFONY_VERSION='~3.2'
+    - php: '5.3'
+    - php: '5.3'
+      env: deps='low'
+    - php: '5.4'
+    - php: '5.5'
+    - php: '5.6'
+    - php: '7.0'
+    - php: '7.1'
 
-
-before_install:
-  - composer self-update
-  - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
-
-install: composer install
+install:
+  - if [[ ! $deps ]]; then composer update --prefer-dist --no-progress --no-suggest --ansi; fi
+  - if [[ $deps = 'low' ]]; then composer update --prefer-dist --no-progress --no-suggest --prefer-stable --prefer-lowest --ansi; fi
 
 script:
-  - php vendor/bin/phpunit --coverage-text
+  - vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ cache:
 matrix:
   include:
     - php: '5.3'
-    - php: '5.3'
-      env: deps='low'
     - php: '5.4'
     - php: '5.5'
     - php: '5.6'
     - php: '7.0'
     - php: '7.1'
+    - php: '7.1'
+      env: deps='low'
 
 install:
   - if [[ ! $deps ]]; then composer update --prefer-dist --no-progress --no-suggest --ansi; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 
 sudo: false
 
-dist: precise
-
 cache:
   directories:
     - $HOME/.composer/cache
@@ -11,6 +9,7 @@ cache:
 matrix:
   include:
     - php: '5.3'
+      dist: 'precise'
     - php: '5.4'
     - php: '5.5'
     - php: '5.6'

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,16 @@
         }
     ],
     "require":      {
-        "symfony/framework-bundle": "~2.0|~3.0",
-        "knplabs/gaufrette":        "~0.1.7|~0.2|~0.3"
+        "knplabs/gaufrette": "~0.1.7|~0.2|~0.3",
+        "symfony/config": "~2.1|~3.0",
+        "symfony/dependency-injection": "~2.1|~3.0",
+        "symfony/framework-bundle": "~2.0|~3.0"
     },
     "require-dev": {
-        "symfony/yaml": "~2.0|~3.0",
-        "symfony/console": "~2.0|~3.0",
-        "phpunit/phpunit": "~4.2"
+        "phpunit/phpunit": "~4.2",
+        "symfony/console": "~2.1|~3.0",
+        "symfony/filesystem": "~2.1|~3.0",
+        "symfony/yaml": "~2.1|~3.0"
     },
     "autoload":     {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
+<!-- http://phpunit.de/manual/4.1/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.6/phpunit.xsd"
+         backupGlobals="false"
          bootstrap="vendor/autoload.php"
+         colors="true"
 >
+  <php>
+    <ini name="error_reporting" value="-1" />
+    <ini name="memory_limit" value="-1" />
+    <server name="KERNEL_DIR" value="Tests/Functional/" />
+  </php>
   <testsuites>
     <testsuite name="KnpGaufretteBundle Test Suite">
-      <directory>./Tests</directory>
+      <directory>Tests</directory>
     </testsuite>
   </testsuites>
 
@@ -21,9 +22,9 @@
     <whitelist>
       <directory suffix=".php">.</directory>
       <exclude>
-        <directory>./Resources</directory>
-        <directory>./Tests</directory>
-        <directory>./vendor</directory>
+        <directory>Resources</directory>
+        <directory>Tests</directory>
+        <directory>vendor</directory>
       </exclude>
     </whitelist>
   </filter>


### PR DESCRIPTION
This PR changes the way we run tests.

Currently, we test again different versions of Symfony by specifying an env var and require the whole framework to run the test suite. This is problematic because it hides potential missing dependencies in `composer.json`.

So instead, we require all the components we are using and we run the tests again the lowest and highest resolvable dependencies. This covers all Symfony's versions thanks to their [Backward Compatibility Promise](http://symfony.com/doc/current/contributing/code/bc.html).

Sadly, it's not possible to use versions `<2.1` of Symfony's components since they lack an `autoload` key in their `composer.json`.