### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/FilesystemMapTest.php
+++ b/Tests/FilesystemMapTest.php
@@ -3,8 +3,9 @@
 namespace Knp\Bundle\GaufretteBundle\Tests;
 
 use Knp\Bundle\GaufretteBundle\FilesystemMap;
+use PHPUnit\Framework\TestCase;
 
-class FilesystemMapTest extends \PHPUnit_Framework_TestCase
+class FilesystemMapTest extends TestCase
 {
     private $filesystemMap;
 

--- a/Tests/Functional/ConfigurationTest.php
+++ b/Tests/Functional/ConfigurationTest.php
@@ -4,8 +4,9 @@ namespace Knp\Bundle\GaufretteBundle\Tests\Functional;
 
 use Symfony\Component\Filesystem\Filesystem;
 use Gaufrette\StreamWrapper;
+use PHPUnit\Framework\TestCase;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     private $cacheDir;
     private $kernel;

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/framework-bundle": "~2.0|~3.0|~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.2",
+        "phpunit/phpunit": "~4.8.35",
         "symfony/console": "~2.1|~3.0|~4.0",
         "symfony/filesystem": "~2.1|~3.0|~4.0",
         "symfony/yaml": "~2.1|~3.0|~4.0"


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.