### PR TITLE
fix composer.json validity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.5.x-branch"
+            "dev-master": "0.5.x-dev"
         }
     }
 }


### PR DESCRIPTION
Before : 
```
$ composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
extra.branch-alias.dev-master : the target branch (0.5.x-branch) must end in -dev
```
After : 
```
$ composer validate      
./composer.json is valid
```

Fixing the validity of `composer.json` file as we got noticed by email of these errors.