### PR TITLE
be able to install gaufrette v0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require":      {
-        "knplabs/gaufrette": "~0.1.7|~0.2|~0.3|~0.4|~0.5|~0.6",
+        "knplabs/gaufrette": "~0.1.7|~0.2|~0.3|~0.4|~0.5|~0.6|~0.7",
         "symfony/config": "~2.1|~3.0|~4.0",
         "symfony/dependency-injection": "~2.1|~3.0|~4.0",
         "symfony/framework-bundle": "~2.0|~3.0|~4.0"


### PR DESCRIPTION
As [v0.7.0](https://github.com/KnpLabs/Gaufrette/releases/tag/v0.7.0) is out.