### PR TITLE
Remove TreeBuilder deprecations

### DIFF
--- a/DependencyInjection/FactoryConfiguration.php
+++ b/DependencyInjection/FactoryConfiguration.php
@@ -19,11 +19,11 @@ class FactoryConfiguration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        if(method_exists(TreeBuilder::class, 'getRootNode')) {
+        // Solves Symfony 4.2 TreeBuilder deprecation
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
             $treeBuilder = new TreeBuilder('knp_gaufrette');
             $rootNode    = $treeBuilder->getRootNode();
-        }
-        else {
+        } else {
             $treeBuilder = new TreeBuilder();
             $rootNode    = $treeBuilder->root('knp_gaufrette');
         }

--- a/DependencyInjection/FactoryConfiguration.php
+++ b/DependencyInjection/FactoryConfiguration.php
@@ -18,19 +18,24 @@ class FactoryConfiguration implements ConfigurationInterface
      * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
-    {
-        $treeBuilder = new TreeBuilder();
+        if(method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('knp_gaufrette');
+            $rootNode    = $treeBuilder->getRootNode();
+        }
+        else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode    = $treeBuilder->root('knp_gaufrette');
+        }
 
-        $treeBuilder
-            ->root('knp_gaufrette')
-                ->ignoreExtraKeys()
-                ->fixXmlConfig('factory', 'factories')
-                ->children()
-                    ->arrayNode('factories')
-                        ->prototype('scalar')->end()
-                    ->end()
+        $rootNode
+            ->ignoreExtraKeys()
+            ->fixXmlConfig('factory', 'factories')
+            ->children()
+                ->arrayNode('factories')
+                    ->prototype('scalar')->end()
                 ->end()
             ->end()
+        ->end()
         ;
 
         return $treeBuilder;

--- a/DependencyInjection/FactoryConfiguration.php
+++ b/DependencyInjection/FactoryConfiguration.php
@@ -18,6 +18,7 @@ class FactoryConfiguration implements ConfigurationInterface
      * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
+    {
         if(method_exists(TreeBuilder::class, 'getRootNode')) {
             $treeBuilder = new TreeBuilder('knp_gaufrette');
             $rootNode    = $treeBuilder->getRootNode();

--- a/DependencyInjection/MainConfiguration.php
+++ b/DependencyInjection/MainConfiguration.php
@@ -32,11 +32,11 @@ class MainConfiguration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        if(method_exists(TreeBuilder::class, 'getRootNode')) {
+        // Solves Symfony 4.2 TreeBuilder deprecation
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
             $treeBuilder = new TreeBuilder('knp_gaufrette');
             $rootNode    = $treeBuilder->getRootNode();
-        }
-        else {
+        } else {
             $treeBuilder = new TreeBuilder();
             $rootNode    = $treeBuilder->root('knp_gaufrette');
         }

--- a/DependencyInjection/MainConfiguration.php
+++ b/DependencyInjection/MainConfiguration.php
@@ -32,8 +32,14 @@ class MainConfiguration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('knp_gaufrette');
+        if(method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('knp_gaufrette');
+            $rootNode    = $treeBuilder->getRootNode();
+        }
+        else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode    = $treeBuilder->root('knp_gaufrette');
+        }
 
         $this->addAdaptersSection($rootNode, $this->factories);
         $this->addFilesystemsSection($rootNode);


### PR DESCRIPTION
These changes remove the Symfony 4.2 deprecation "A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0."