### PR TITLE
using ContainerAwareCommand deprecated in symfony 4.2

### DIFF
--- a/Command/FilesystemKeysCommand.php
+++ b/Command/FilesystemKeysCommand.php
@@ -2,7 +2,7 @@
 
 namespace Knp\Bundle\GaufretteBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -13,7 +13,7 @@ use Gaufrette\Glob;
  *
  * @author Antoine Hérault <antoine.herault@gmail.com>
  */
-class FilesystemKeysCommand extends ContainerAwareCommand
+class FilesystemKeysCommand extends Command
 {
     /**
      * {@inheritDoc}


### PR DESCRIPTION
After upgrading to symfony 4.2 getting this deprecation error

` 1x: The "Knp\Bundle\GaufretteBundle\Command\FilesystemKeysCommand" class extends "Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand" that is deprecated since Symfony 4.2, use {@see Command} instead.`

changing to use "Symfony\Component\Console\Command\Command" fixes this issue