### PR TITLE
Fix/command deprecation

### DIFF
--- a/Command/FilesystemKeysCommand.php
+++ b/Command/FilesystemKeysCommand.php
@@ -2,7 +2,7 @@
 
 namespace Knp\Bundle\GaufretteBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -13,7 +13,7 @@ use Gaufrette\Glob;
  *
  * @author Antoine Hérault <antoine.herault@gmail.com>
  */
-class FilesystemKeysCommand extends ContainerAwareCommand
+class FilesystemKeysCommand extends Command
 {
     /**
      * {@inheritDoc}

--- a/Command/FilesystemKeysCommand.php
+++ b/Command/FilesystemKeysCommand.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
+use Gaufrette\FilesystemMapInterface;
 use Gaufrette\Glob;
 
 /**
@@ -15,6 +16,17 @@ use Gaufrette\Glob;
  */
 class FilesystemKeysCommand extends Command
 {
+    /**
+     * @var FilesystemMapInterface
+     */
+    private $filesystemMap;
+
+    public function __construct(FilesystemMapInterface $filesystemMap)
+    {
+        $this->filesystemMap = $filesystemMap;
+
+        parent::__construct();
+    }
     /**
      * {@inheritDoc}
      */
@@ -42,16 +54,14 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $filesystem = $input->getArgument('filesystem');
-        $glob       = $input->getArgument('glob');
-        $container  = $this->getContainer();
-        $serviceId  = sprintf('gaufrette.%s_filesystem', $filesystem);
+        $filesystemName = $input->getArgument('filesystem');
+        $glob = $input->getArgument('glob');
 
-        if (!$container->has($serviceId)) {
+        if (!$this->filesystemMap->has($filesystemName)) {
             throw new \RuntimeException(sprintf('There is no \'%s\' filesystem defined.', $filesystem));
         }
 
-        $filesystem = $container->get($serviceId);
+        $filesystem = $this->filesystemMap->get($filesystemName);
         $keys       = $filesystem->keys();
 
         if (!empty($glob)) {

--- a/FilesystemMap.php
+++ b/FilesystemMap.php
@@ -2,11 +2,13 @@
 
 namespace Knp\Bundle\GaufretteBundle;
 
+use Gaufrette\FilesystemMapInterface;
+
 /**
  * Holds references to all declared filesystems
  * and allows to access them through their name.
  */
-class FilesystemMap implements \IteratorAggregate
+class FilesystemMap implements \IteratorAggregate, FilesystemMapInterface
 {
     /**
      * Map of filesystems indexed by their name.

--- a/Resources/config/gaufrette.xml
+++ b/Resources/config/gaufrette.xml
@@ -54,6 +54,7 @@
         <service id="knp_gaufrette.adapter.dropbox" class="Gaufrette\Adapter\Dropbox" abstract="true" public="false" />
 
         <service id="knp_gaufrette.command.filesystem_keys" class="Knp\Bundle\GaufretteBundle\Command\FilesystemKeysCommand">
+            <argument type="service" id="knp_gaufrette.filesystem_map" />
             <tag name="console.command" command="gaufrette:filesystem:keys" />
         </service>
     </services>

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require":      {
         "php": ">=7.1",
-        "knplabs/gaufrette": "^0.8",
+        "knplabs/gaufrette": "^0.8.2",
         "symfony/config": "^3.4|^4.0",
         "symfony/dependency-injection": "^3.4|^4.0",
         "symfony/framework-bundle": "^3.4|^4.0"


### PR DESCRIPTION
Related to #209 .
As @timgregg pointed out, the SF 4.2 have a deprecation on the `ContainerAwareCommand` class, and the services used in a command [should be injected as dependencies](https://symfony.com/blog/new-in-symfony-4-2-important-deprecations).

This PR completes the work of #209 by injecting the dependency.

## TODO
- [x] explicitly require a version of Gaufrette having the `FilesystemMapInterface`