### PR TITLE
Fix Symfony 3.4 deprecation: Autowiring based on types.

### DIFF
--- a/Resources/config/gaufrette.xml
+++ b/Resources/config/gaufrette.xml
@@ -51,6 +51,7 @@
         <service id="knp_gaufrette.filesystem_map" class="%knp_gaufrette.filesystem_map.class%" public="true">
             <argument /> <!-- map of filesystems -->
         </service>
+        <service id="%knp_gaufrette.filesystem_map.class%" alias="knp_gaufrette.filesystem_map" public="false"/>
         <service id="knp_gaufrette.adapter.dropbox" class="Gaufrette\Adapter\Dropbox" abstract="true" public="false" />
 
         <service id="knp_gaufrette.command.filesystem_keys" class="Knp\Bundle\GaufretteBundle\Command\FilesystemKeysCommand">


### PR DESCRIPTION
"Autowiring services based on the types they implement is not supported anymore. It will only look for an alias or a service id that matches a given FQCN. Rename (or alias) your services to their FQCN id to make them autowirable."

cf. https://github.com/symfony/symfony/blob/master/UPGRADE-4.0.md

This makes FilesystemMap autowirable in Symfony 4.

EDIT: This would also allow to autowire FilesystemMap in FilesystemKeysCommand without adding FilesystemMapInterface in https://github.com/KnpLabs/KnpGaufretteBundle/pull/210.