### PR TITLE
be able to use SF 3.4 as it is LTS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
     "require":      {
         "php": ">=7.1",
         "knplabs/gaufrette": "^0.8",
-        "symfony/config": "^4.0",
-        "symfony/dependency-injection": "^4.0",
-        "symfony/framework-bundle": "^4.0"
+        "symfony/config": "^3.4|^4.0",
+        "symfony/dependency-injection": "^3.4|^4.0",
+        "symfony/framework-bundle": "^3.4|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.5",
-        "symfony/console": "^4.0",
-        "symfony/filesystem": "^4.0",
-        "symfony/yaml": "^4.0"
+        "symfony/console": "^3.4|^4.0",
+        "symfony/filesystem": "^3.4|^4.0",
+        "symfony/yaml": "^3.4|^4.0"
     },
     "autoload":     {
         "psr-4": {


### PR DESCRIPTION
Fixes #220 

There was a mistake on the depedencies update. SF 3.4 is LTS until the
end of 2021, so the bundle should be usable with this SF version.