### PR TITLE
Fix command name in help

### DIFF
--- a/Command/FilesystemKeysCommand.php
+++ b/Command/FilesystemKeysCommand.php
@@ -38,13 +38,13 @@ class FilesystemKeysCommand extends Command
             ->addArgument('filesystem', InputArgument::REQUIRED, 'The filesystem to use')
             ->addArgument('glob', InputArgument::OPTIONAL, 'An optional glob pattern')
             ->setHelp(<<<EOT
-The <info>gaufrette:filesystem:list</info> command lists all the file keys of the specified filesystem:
+The <info>%command.name%</info> command lists all the file keys of the specified filesystem:
 
-    <info>./app/console gaufrette:filesystem:list my_filesystem</info>
+    <info>php %command.full_name% my_filesystem</info>
 
 You can also optionaly specify a glob pattern to filter the results:
 
-    <info>./app/console gaufrette:filesystem:list my_filesystem media_*</info>
+    <info>php %command.full_name% my_filesystem media_*</info>
 EOT
             );
     }


### PR DESCRIPTION
The command name in not up to date in the help message.

### Before
```
$ symfony console gaufrette:filesystem:keys -h
Description:
  List all the file keys of a filesystem

Usage:
  gaufrette:filesystem:keys <filesystem> [<glob>]

Arguments:
  filesystem            The filesystem to use
  glob                  An optional glob pattern

Options:
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -e, --env=ENV         The Environment name. [default: "dev"]
      --no-debug        Switches off debug mode.
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  The gaufrette:filesystem:list command lists all the file keys of the specified filesystem:
  
      ./app/console gaufrette:filesystem:list my_filesystem
  
  You can also optionaly specify a glob pattern to filter the results:
  
      ./app/console gaufrette:filesystem:list my_filesystem media_*

```

### After
```
$ symfony console gaufrette:filesystem:keys -h
Description:
  List all the file keys of a filesystem

Usage:
  gaufrette:filesystem:keys <filesystem> [<glob>]

Arguments:
  filesystem            The filesystem to use
  glob                  An optional glob pattern

Options:
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -e, --env=ENV         The Environment name. [default: "dev"]
      --no-debug        Switches off debug mode.
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  The gaufrette:filesystem:keys command lists all the file keys of the specified filesystem:
  
      php bin/console gaufrette:filesystem:keys my_filesystem
  
  You can also optionaly specify a glob pattern to filter the results:
  
      php bin/console gaufrette:filesystem:keys my_filesystem media_*

```