### PR TITLE
[doc] fixed async_aws_s3 configuration example for service definition

### DIFF
--- a/Resources/docs/adapters/async-aws-s3.md
+++ b/Resources/docs/adapters/async-aws-s3.md
@@ -19,7 +19,6 @@ An example service definition of the `AsyncAws\SimpleS3\SimpleS3Client`:
 services:
     acme.async_aws_s3.client:
         class: AsyncAws\SimpleS3\SimpleS3Client
-        factory: [Aws\S3\S3Client, 'factory']
         arguments:
             - region: '%amazon_s3.region%'
               accessKeyId: '%amazon_s3.key%'


### PR DESCRIPTION
SimpleS3Client cannot be created from `Aws\S3\S3Client::create()`.
Maybe it's copy-pasted from aws_s3 adapter configuration doc :grin: