### PR TITLE
Fix FilesystemMap::getIterator() return type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
     - php: '7.2'
     - php: '7.3'
     - php: '7.4'
+    - php: '8.0'
+    - php: '8.1'
 
 install:
   - composer update --prefer-dist --no-progress --no-suggest --ansi

--- a/FilesystemMap.php
+++ b/FilesystemMap.php
@@ -55,7 +55,7 @@ class FilesystemMap implements \IteratorAggregate, FilesystemMapInterface
         return isset($this->maps[$name]);
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->maps);
     }


### PR DESCRIPTION
Hello :wave: 

I fixed the following deprecation : 

```
Deprecated: Return type of Knp\Bundle\GaufretteBundle\FilesystemMap::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /srv/vendor/knplabs/knp-gaufrette-bundle/FilesystemMap.php on line 58
```

I'm not sure if we should bump the minimal PHP version as well, let me know if it's all right with you :)
