### PR TITLE
Removes deprecations for Symfony 5.4/6.0 compatibility

### DIFF
--- a/Command/FilesystemKeysCommand.php
+++ b/Command/FilesystemKeysCommand.php
@@ -52,7 +52,7 @@ EOT
     /**
      * {@inheritDoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $filesystemName = $input->getArgument('filesystem');
         $glob = $input->getArgument('glob');

--- a/DependencyInjection/FactoryConfiguration.php
+++ b/DependencyInjection/FactoryConfiguration.php
@@ -17,7 +17,7 @@ class FactoryConfiguration implements ConfigurationInterface
      *
      * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('knp_gaufrette');
         if (method_exists($treeBuilder, 'getRootNode')) {

--- a/DependencyInjection/KnpGaufretteExtension.php
+++ b/DependencyInjection/KnpGaufretteExtension.php
@@ -2,6 +2,8 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection;
 
+use Exception;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -23,8 +25,10 @@ class KnpGaufretteExtension extends Extension
     /**
      * Loads the extension
      *
-     * @param  array            $configs
-     * @param  ContainerBuilder $container
+     * @param array $configs
+     * @param ContainerBuilder $container
+     *
+     * @throws Exception
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -54,7 +58,7 @@ class KnpGaufretteExtension extends Extension
         }
     }
 
-    public function getConfiguration(array $configs, ContainerBuilder $container)
+    public function getConfiguration(array $configs, ContainerBuilder $container): ?ConfigurationInterface
     {
         // first assemble the adapter factories
         $factoryConfig = new FactoryConfiguration();

--- a/DependencyInjection/MainConfiguration.php
+++ b/DependencyInjection/MainConfiguration.php
@@ -30,7 +30,7 @@ class MainConfiguration implements ConfigurationInterface
      *
      * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('knp_gaufrette');
         if (method_exists($treeBuilder, 'getRootNode')) {

--- a/FilesystemMap.php
+++ b/FilesystemMap.php
@@ -55,7 +55,7 @@ class FilesystemMap implements \IteratorAggregate, FilesystemMapInterface
         return isset($this->maps[$name]);
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->maps);
     }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require":      {
-        "php": ">=7.4",
+        "php": ">=7.1",
         "knplabs/gaufrette": "^0.10",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require":      {
-        "php": ">=7.1",
+        "php": ">=7.4",
         "knplabs/gaufrette": "^0.10",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",


### PR DESCRIPTION
Hi there,
i've removed deprecations for Symfony 5.4 and 6.0 compatibility.
As the deprecations are removed by adding type declarations, the php version required is `>= 7.4` [as documentation says](https://www.php.net/manual/en/language.types.declarations.php)