### PR TITLE
Re-enable CI: using GitHub Actions, with PHP 8.0 & 8.1 !

### DIFF
--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  tests:
+    name: PHPUnit
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress --no-suggest --ansi
+
+      - name: Run PHPUnit tests
+        run: vendor/bin/simple-phpunit --coverage-text


### PR DESCRIPTION
This stands as a replacement for https://github.com/KnpLabs/KnpGaufretteBundle/pull/262