### PR TITLE
:arrow_up: Add support for PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1', '8.2']
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
⚠️ Gaufrette is not tested against PHP 8.2 yet. (which seems to have issues with streams in PHP 8.2, and have dependency prophecy not compatible yet with PHP 8.2)