### PR TITLE
Fix symfony 6.3 return type deprecations

### DIFF
--- a/DependencyInjection/KnpGaufretteExtension.php
+++ b/DependencyInjection/KnpGaufretteExtension.php
@@ -26,6 +26,8 @@ class KnpGaufretteExtension extends Extension
      *
      * @param  array            $configs
      * @param  ContainerBuilder $container
+     * 
+     * @return void
      */
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/KnpGaufretteBundle.php
+++ b/KnpGaufretteBundle.php
@@ -13,6 +13,9 @@ use Gaufrette\StreamWrapper;
  */
 class KnpGaufretteBundle extends Bundle
 {
+    /**
+     * @return void
+     */
     public function boot()
     {
         parent::boot();


### PR DESCRIPTION
Fixes 2 symfony 6.3 deprecation warnings

> Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Knp\Bundle\GaufretteBundle\DependencyInjection\KnpGaufretteExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

> User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::boot()" might add "void" as a native return type declaration in the future. Do the same in child class "Knp\Bundle\GaufretteBundle\KnpGaufretteBundle" now to avoid errors or add an explicit @return annotation to suppress this message.