### PR TITLE
Remove Symfony deprecation

### DIFF
--- a/DependencyInjection/KnpGaufretteExtension.php
+++ b/DependencyInjection/KnpGaufretteExtension.php
@@ -29,7 +29,7 @@ class KnpGaufretteExtension extends Extension
      * 
      * @return void
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
 


### PR DESCRIPTION
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future