### PR TITLE
fix(php8.2): void as a native return type

### DIFF
--- a/KnpGaufretteBundle.php
+++ b/KnpGaufretteBundle.php
@@ -16,7 +16,7 @@ class KnpGaufretteBundle extends Bundle
     /**
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         parent::boot();
 

--- a/Tests/Functional/TestKernel.php
+++ b/Tests/Functional/TestKernel.php
@@ -19,7 +19,7 @@ class TestKernel extends Kernel
         );
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/Resources/config/config_'.$this->getEnvironment().'.yml');
     }


### PR DESCRIPTION
Fix depreciations for symfony 6.3 and php 8.2
```
User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::boot()" might add "void" as a native return type declaration in the future. Do the same in child class "Knp\Bundle\GaufretteBundle\KnpGaufretteBundle" now to avoid errors.
```