### PR TITLE
Fix compatibility with Symfony 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+v0.10.0
+=======
+
+Adds :
+
+- Symfony 8 support (#290)
+
+v0.9.0 - 2023-12-18
+===================
+
+Adds :
+
+- Symfony 7 support (#282)
+
+Fixes :
+
+- Remove Symfony deprecation notice about `ExtensionInterface::load()` return type (#279)
+- Fix Symfony 6.3 return type deprecations (#278)
+- Fix void as a native return type for PHP 8.2 (#280)
+
+Removes :
+
+- Unused `symfony/framework-bundle` dependency (#243)
+
 v0.8.0 - 2022-10-21
 ===================
 

--- a/Resources/config/gaufrette.php
+++ b/Resources/config/gaufrette.php
@@ -116,6 +116,6 @@ return function (ContainerConfigurator $configurator) {
 
     $services
         ->set('knp_gaufrette.command.filesystem_keys', FilesystemKeysCommand::class)
-        ->arg(0, service('knp_gaufrette.filesystem_map'))
+        ->arg(0, new ReferenceConfigurator('knp_gaufrette.filesystem_map'))
         ->tag('console.command', ['command' => 'gaufrette:filesystem:keys']);
 };


### PR DESCRIPTION
Remove the service call in favor of the ReferenceConfigurator constructor to maintain compatibility with Symfony versions prior to 5.1. Update the changelog to reflect support for Symfony 8.