### PR TITLE
feat!: add full PHP 8.0–8.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,8 @@ jobs:
           composer update --no-progress --ansi
           composer update --no-progress --ansi ${{ matrix.dependency-version }}
 
+      - name: Validate PHP syntax
+        run: find . -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P4 php -l
+
       - name: Run PHPUnit tests
         run: vendor/bin/simple-phpunit --coverage-text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        dependency-version: [prefer-lowest, prefer-stable]
     steps:
       - uses: actions/checkout@v7
 
@@ -29,7 +30,9 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install dependencies
-        run: composer update --prefer-dist --no-progress --no-suggest --ansi
+        run: |
+          composer update --no-progress --ansi
+          composer update --no-progress --ansi ${{ matrix.dependency-version }}
 
       - name: Run PHPUnit tests
         run: vendor/bin/simple-phpunit --coverage-text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [Unreleased] — PHP 8.0–8.5 compatibility (MAJOR)
+
+### ⚠ BREAKING CHANGES
+
+* **`AdapterFactoryInterface::create()`** now declares `string $id` as an explicit parameter type.
+  Any class implementing this interface must update its `create()` signature accordingly:
+  ```php
+  // Before
+  public function create(ContainerBuilder $container, $id, array $config): void { … }
+  // After
+  public function create(ContainerBuilder $container, string $id, array $config): void { … }
+  ```
+
+### Features
+
+* Full PHP 8.0–8.5 support: `composer install` resolves cleanly and all tests pass on all six versions.
+* Expand `symfony/phpunit-bridge` constraint to `^6.0|^7.0|^8.0` (previously `^7.0|^8.0`,
+  which blocked PHP 8.0/8.1 since Bridge 7.x requires PHP 8.2).
+
+### Internal Changes
+
+* Add explicit type declarations to class properties in `FilesystemMap`, `KnpGaufretteExtension`,
+  and `FilesystemKeysCommand`.
+* Remove dead `use DefinitionDecorator` import from `KnpGaufretteExtension`.
+* Replace legacy `array()` literals with `[]` short syntax in `KnpGaufretteExtension` and
+  both compiler passes.
+* Update `phpunit.xml.dist` schema reference from PHPUnit 9.3 to PHPUnit 10.5.
+
+---
+
 ## [0.10.0](https://github.com/KnpLabs/KnpGaufretteBundle/compare/v0.9.0...v0.10.0) (2026-07-18)
 
 ### Features

--- a/Command/FilesystemKeysCommand.php
+++ b/Command/FilesystemKeysCommand.php
@@ -16,12 +16,8 @@ use Gaufrette\Glob;
  */
 class FilesystemKeysCommand extends Command
 {
-    private FilesystemMapInterface $filesystemMap;
-
-    public function __construct(FilesystemMapInterface $filesystemMap)
+    public function __construct(private FilesystemMapInterface $filesystemMap)
     {
-        $this->filesystemMap = $filesystemMap;
-
         parent::__construct();
     }
     /**

--- a/Command/FilesystemKeysCommand.php
+++ b/Command/FilesystemKeysCommand.php
@@ -16,10 +16,7 @@ use Gaufrette\Glob;
  */
 class FilesystemKeysCommand extends Command
 {
-    /**
-     * @var FilesystemMapInterface
-     */
-    private $filesystemMap;
+    private FilesystemMapInterface $filesystemMap;
 
     public function __construct(FilesystemMapInterface $filesystemMap)
     {

--- a/Command/FilesystemKeysCommand.php
+++ b/Command/FilesystemKeysCommand.php
@@ -7,7 +7,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
 use Gaufrette\FilesystemMapInterface;
-use Gaufrette\Glob;
 
 /**
  * Command that lists the file keys of a filesystem
@@ -29,15 +28,10 @@ class FilesystemKeysCommand extends Command
             ->setName('gaufrette:filesystem:keys')
             ->setDescription('List all the file keys of a filesystem')
             ->addArgument('filesystem', InputArgument::REQUIRED, 'The filesystem to use')
-            ->addArgument('glob', InputArgument::OPTIONAL, 'An optional glob pattern')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command lists all the file keys of the specified filesystem:
 
     <info>php %command.full_name% my_filesystem</info>
-
-You can also optionaly specify a glob pattern to filter the results:
-
-    <info>php %command.full_name% my_filesystem media_*</info>
 EOT
             );
     }
@@ -48,7 +42,6 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $filesystemName = $input->getArgument('filesystem');
-        $glob = $input->getArgument('glob');
 
         if (!$this->filesystemMap->has($filesystemName)) {
             throw new \RuntimeException(sprintf('There is no \'%s\' filesystem defined.', $filesystemName));
@@ -56,11 +49,6 @@ EOT
 
         $filesystem = $this->filesystemMap->get($filesystemName);
         $keys       = $filesystem->keys();
-
-        if (!empty($glob)) {
-            $glob = new Glob($glob);
-            $keys = $glob->filter($keys);
-        }
 
         $count = count($keys);
 

--- a/DependencyInjection/Compiler/AdapterFactoryManagerPass.php
+++ b/DependencyInjection/Compiler/AdapterFactoryManagerPass.php
@@ -26,7 +26,7 @@ class AdapterFactoryManagerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('gaufrette.adapter_factory') as $id => $attributes) {
             if (!empty($attributes['type'])) {
-                $definition->addMethodCall('set', array($attributes['type'], new Reference($id)));
+                $definition->addMethodCall('set', [$attributes['type'], new Reference($id)]);
             }
         }
 

--- a/DependencyInjection/Compiler/AdapterFactoryManagerPass.php
+++ b/DependencyInjection/Compiler/AdapterFactoryManagerPass.php
@@ -22,7 +22,7 @@ class AdapterFactoryManagerPass implements CompilerPassInterface
         $definition = $container->getDefinition('knp_gaufrette.adapter_factory_manager');
 
         $calls = $definition->getMethodCalls();
-        $definition->setMethodCalls(array());
+        $definition->setMethodCalls([]);
 
         foreach ($container->findTaggedServiceIds('gaufrette.adapter_factory') as $id => $attributes) {
             if (!empty($attributes['type'])) {

--- a/DependencyInjection/Compiler/AdapterManagerPass.php
+++ b/DependencyInjection/Compiler/AdapterManagerPass.php
@@ -25,7 +25,7 @@ class AdapterManagerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('gaufrette.adapter') as $id => $attributes) {
             if (!empty($attributes['alias'])) {
-                $definition->addMethodCall('set', array($attributes['alias'], new Reference($id)));
+                $definition->addMethodCall('set', [$attributes['alias'], new Reference($id)]);
             }
         }
 

--- a/DependencyInjection/Compiler/AdapterManagerPass.php
+++ b/DependencyInjection/Compiler/AdapterManagerPass.php
@@ -21,7 +21,7 @@ class AdapterManagerPass implements CompilerPassInterface
 
         $definition = $container->getDefinition('knp_gaufrette.adapter_manager');
         $calls = $definition->getMethodCalls();
-        $definition->setMethodCalls(array());
+        $definition->setMethodCalls([]);
 
         foreach ($container->findTaggedServiceIds('gaufrette.adapter') as $id => $attributes) {
             if (!empty($attributes['alias'])) {

--- a/DependencyInjection/Factory/AdapterFactoryInterface.php
+++ b/DependencyInjection/Factory/AdapterFactoryInterface.php
@@ -19,7 +19,7 @@ interface AdapterFactoryInterface
      * @param  string           $id         The id of the service
      * @param  array            $config     An array of configuration
      */
-    public function create(ContainerBuilder $container, $id, array $config): void;
+    public function create(ContainerBuilder $container, string $id, array $config): void;
 
     /**
      * Returns the key for the factory configuration

--- a/DependencyInjection/Factory/AdapterFactoryInterface.php
+++ b/DependencyInjection/Factory/AdapterFactoryInterface.php
@@ -2,7 +2,7 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -31,7 +31,7 @@ interface AdapterFactoryInterface
     /**
      * Adds configuration nodes for the factory
      *
-     * @param  NodeDefinition $builder
+     * @param  ArrayNodeDefinition $builder
      */
-    public function addConfiguration(NodeDefinition $builder): void;
+    public function addConfiguration(ArrayNodeDefinition $builder): void;
 }

--- a/DependencyInjection/Factory/AsyncAwsS3AdapterFactory.php
+++ b/DependencyInjection/Factory/AsyncAwsS3AdapterFactory.php
@@ -13,7 +13,7 @@ class AsyncAwsS3AdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
             ? new ChildDefinition('knp_gaufrette.adapter.async_aws_s3')

--- a/DependencyInjection/Factory/AsyncAwsS3AdapterFactory.php
+++ b/DependencyInjection/Factory/AsyncAwsS3AdapterFactory.php
@@ -2,10 +2,9 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
 class AsyncAwsS3AdapterFactory implements AdapterFactoryInterface
@@ -15,9 +14,7 @@ class AsyncAwsS3AdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.adapter.async_aws_s3')
-            : new DefinitionDecorator('knp_gaufrette.adapter.async_aws_s3');
+        $childDefinition = new ChildDefinition('knp_gaufrette.adapter.async_aws_s3');
 
         $container
             ->setDefinition($id, $childDefinition)
@@ -39,7 +36,7 @@ class AsyncAwsS3AdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $builder): void
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         $builder
             ->children()

--- a/DependencyInjection/Factory/AsyncAwsS3AdapterFactory.php
+++ b/DependencyInjection/Factory/AsyncAwsS3AdapterFactory.php
@@ -15,7 +15,7 @@ class AsyncAwsS3AdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.adapter.async_aws_s3')
             : new DefinitionDecorator('knp_gaufrette.adapter.async_aws_s3');
 

--- a/DependencyInjection/Factory/AwsS3AdapterFactory.php
+++ b/DependencyInjection/Factory/AwsS3AdapterFactory.php
@@ -15,7 +15,7 @@ class AwsS3AdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.adapter.aws_s3')
             : new DefinitionDecorator('knp_gaufrette.adapter.aws_s3');
 

--- a/DependencyInjection/Factory/AwsS3AdapterFactory.php
+++ b/DependencyInjection/Factory/AwsS3AdapterFactory.php
@@ -2,10 +2,9 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
 class AwsS3AdapterFactory implements AdapterFactoryInterface
@@ -15,9 +14,7 @@ class AwsS3AdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.adapter.aws_s3')
-            : new DefinitionDecorator('knp_gaufrette.adapter.aws_s3');
+        $childDefinition = new ChildDefinition('knp_gaufrette.adapter.aws_s3');
 
         $container
             ->setDefinition($id, $childDefinition)
@@ -39,7 +36,7 @@ class AwsS3AdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $builder): void
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         $builder
             ->children()

--- a/DependencyInjection/Factory/AwsS3AdapterFactory.php
+++ b/DependencyInjection/Factory/AwsS3AdapterFactory.php
@@ -13,7 +13,7 @@ class AwsS3AdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
             ? new ChildDefinition('knp_gaufrette.adapter.aws_s3')

--- a/DependencyInjection/Factory/AzureBlobStorageAdapterFactory.php
+++ b/DependencyInjection/Factory/AzureBlobStorageAdapterFactory.php
@@ -14,7 +14,7 @@ class AzureBlobStorageAdapterFactory implements AdapterFactoryInterface
 /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $definition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
             ? new ChildDefinition('knp_gaufrette.adapter.azure_blob_storage')

--- a/DependencyInjection/Factory/AzureBlobStorageAdapterFactory.php
+++ b/DependencyInjection/Factory/AzureBlobStorageAdapterFactory.php
@@ -16,7 +16,7 @@ class AzureBlobStorageAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $definition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $definition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.adapter.azure_blob_storage')
             : new DefinitionDecorator('knp_gaufrette.adapter.azure_blob_storage');
 
@@ -43,9 +43,7 @@ class AzureBlobStorageAdapterFactory implements AdapterFactoryInterface
     {
         $builder
             ->validate()
-            ->ifTrue(function ($v) {
-                return empty($v['container_name']) && !$v['multi_container_mode'];
-            })
+            ->ifTrue(fn($v) => empty($v['container_name']) && !$v['multi_container_mode'])
                 ->thenInvalid('You should either provide a container name or enable the multi container mode.')
             ->end()
             ->children()

--- a/DependencyInjection/Factory/AzureBlobStorageAdapterFactory.php
+++ b/DependencyInjection/Factory/AzureBlobStorageAdapterFactory.php
@@ -2,10 +2,9 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
 
@@ -16,9 +15,7 @@ class AzureBlobStorageAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $definition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.adapter.azure_blob_storage')
-            : new DefinitionDecorator('knp_gaufrette.adapter.azure_blob_storage');
+        $definition = new ChildDefinition('knp_gaufrette.adapter.azure_blob_storage');
 
         $container
             ->setDefinition($id, $definition)
@@ -39,7 +36,7 @@ class AzureBlobStorageAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $builder): void
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         $builder
             ->validate()

--- a/DependencyInjection/Factory/DoctrineDbalAdapterFactory.php
+++ b/DependencyInjection/Factory/DoctrineDbalAdapterFactory.php
@@ -2,10 +2,9 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -20,9 +19,7 @@ class DoctrineDbalAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.adapter.doctrine_dbal')
-            : new DefinitionDecorator('knp_gaufrette.adapter.doctrine_dbal');
+        $childDefinition = new ChildDefinition('knp_gaufrette.adapter.doctrine_dbal');
 
         $definition = $container
             ->setDefinition($id, $childDefinition)
@@ -46,7 +43,7 @@ class DoctrineDbalAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $builder): void
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         $builder
             ->children()

--- a/DependencyInjection/Factory/DoctrineDbalAdapterFactory.php
+++ b/DependencyInjection/Factory/DoctrineDbalAdapterFactory.php
@@ -20,7 +20,7 @@ class DoctrineDbalAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.adapter.doctrine_dbal')
             : new DefinitionDecorator('knp_gaufrette.adapter.doctrine_dbal');
 

--- a/DependencyInjection/Factory/DoctrineDbalAdapterFactory.php
+++ b/DependencyInjection/Factory/DoctrineDbalAdapterFactory.php
@@ -18,7 +18,7 @@ class DoctrineDbalAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
             ? new ChildDefinition('knp_gaufrette.adapter.doctrine_dbal')

--- a/DependencyInjection/Factory/FtpAdapterFactory.php
+++ b/DependencyInjection/Factory/FtpAdapterFactory.php
@@ -17,7 +17,7 @@ class FtpAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.adapter.ftp')
             : new DefinitionDecorator('knp_gaufrette.adapter.ftp');
 
@@ -58,7 +58,7 @@ class FtpAdapterFactory implements AdapterFactoryInterface
                     ->defaultValue(defined('FTP_ASCII') ? FTP_ASCII : null)
                     ->beforeNormalization()
                     ->ifString()
-                    ->then(function($v) { return constant($v); })
+                    ->then(fn($v) => constant($v))
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/Factory/FtpAdapterFactory.php
+++ b/DependencyInjection/Factory/FtpAdapterFactory.php
@@ -15,7 +15,7 @@ class FtpAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
             ? new ChildDefinition('knp_gaufrette.adapter.ftp')

--- a/DependencyInjection/Factory/FtpAdapterFactory.php
+++ b/DependencyInjection/Factory/FtpAdapterFactory.php
@@ -2,10 +2,9 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
 /**
  * Ftp Adapter Factory
@@ -17,9 +16,7 @@ class FtpAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.adapter.ftp')
-            : new DefinitionDecorator('knp_gaufrette.adapter.ftp');
+        $childDefinition = new ChildDefinition('knp_gaufrette.adapter.ftp');
 
         $container
             ->setDefinition($id, $childDefinition)
@@ -40,7 +37,7 @@ class FtpAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $builder): void
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         $builder
             ->children()

--- a/DependencyInjection/Factory/GoogleCloudStorageAdapterFactory.php
+++ b/DependencyInjection/Factory/GoogleCloudStorageAdapterFactory.php
@@ -14,7 +14,7 @@ class GoogleCloudStorageAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
             ? new ChildDefinition('knp_gaufrette.adapter.google_cloud_storage')

--- a/DependencyInjection/Factory/GoogleCloudStorageAdapterFactory.php
+++ b/DependencyInjection/Factory/GoogleCloudStorageAdapterFactory.php
@@ -16,7 +16,7 @@ class GoogleCloudStorageAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.adapter.google_cloud_storage')
             : new DefinitionDecorator('knp_gaufrette.adapter.google_cloud_storage');
 

--- a/DependencyInjection/Factory/GoogleCloudStorageAdapterFactory.php
+++ b/DependencyInjection/Factory/GoogleCloudStorageAdapterFactory.php
@@ -2,10 +2,9 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
 class GoogleCloudStorageAdapterFactory implements AdapterFactoryInterface
@@ -16,9 +15,7 @@ class GoogleCloudStorageAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.adapter.google_cloud_storage')
-            : new DefinitionDecorator('knp_gaufrette.adapter.google_cloud_storage');
+        $childDefinition = new ChildDefinition('knp_gaufrette.adapter.google_cloud_storage');
 
         $container
             ->setDefinition($id, $childDefinition)
@@ -40,7 +37,7 @@ class GoogleCloudStorageAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $builder): void
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         $builder
             ->children()

--- a/DependencyInjection/Factory/GridFSAdapterFactory.php
+++ b/DependencyInjection/Factory/GridFSAdapterFactory.php
@@ -18,7 +18,7 @@ class GridFSAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
             ? new ChildDefinition('knp_gaufrette.adapter.gridfs')

--- a/DependencyInjection/Factory/GridFSAdapterFactory.php
+++ b/DependencyInjection/Factory/GridFSAdapterFactory.php
@@ -2,10 +2,9 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -20,9 +19,7 @@ class GridFSAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.adapter.gridfs')
-            : new DefinitionDecorator('knp_gaufrette.adapter.gridfs');
+        $childDefinition = new ChildDefinition('knp_gaufrette.adapter.gridfs');
 
         $container
             ->setDefinition($id, $childDefinition)
@@ -41,7 +38,7 @@ class GridFSAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $node): void
+    public function addConfiguration(ArrayNodeDefinition $node): void
     {
         $node
         ->children()

--- a/DependencyInjection/Factory/GridFSAdapterFactory.php
+++ b/DependencyInjection/Factory/GridFSAdapterFactory.php
@@ -20,7 +20,7 @@ class GridFSAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.adapter.gridfs')
             : new DefinitionDecorator('knp_gaufrette.adapter.gridfs');
 

--- a/DependencyInjection/Factory/InMemoryAdapterFactory.php
+++ b/DependencyInjection/Factory/InMemoryAdapterFactory.php
@@ -17,7 +17,7 @@ class InMemoryAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
             ? new ChildDefinition('knp_gaufrette.adapter.in_memory')

--- a/DependencyInjection/Factory/InMemoryAdapterFactory.php
+++ b/DependencyInjection/Factory/InMemoryAdapterFactory.php
@@ -19,7 +19,7 @@ class InMemoryAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.adapter.in_memory')
             : new DefinitionDecorator('knp_gaufrette.adapter.in_memory');
 

--- a/DependencyInjection/Factory/InMemoryAdapterFactory.php
+++ b/DependencyInjection/Factory/InMemoryAdapterFactory.php
@@ -2,10 +2,9 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
 /**
  * In memory adapter factory
@@ -19,9 +18,7 @@ class InMemoryAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.adapter.in_memory')
-            : new DefinitionDecorator('knp_gaufrette.adapter.in_memory');
+        $childDefinition = new ChildDefinition('knp_gaufrette.adapter.in_memory');
 
         $container
             ->setDefinition($id, $childDefinition)
@@ -40,7 +37,7 @@ class InMemoryAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $node): void
+    public function addConfiguration(ArrayNodeDefinition $node): void
     {
         $node
             ->children()

--- a/DependencyInjection/Factory/LocalAdapterFactory.php
+++ b/DependencyInjection/Factory/LocalAdapterFactory.php
@@ -19,7 +19,7 @@ class LocalAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.adapter.local')
             : new DefinitionDecorator('knp_gaufrette.adapter.local');
 

--- a/DependencyInjection/Factory/LocalAdapterFactory.php
+++ b/DependencyInjection/Factory/LocalAdapterFactory.php
@@ -17,7 +17,7 @@ class LocalAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
             ? new ChildDefinition('knp_gaufrette.adapter.local')

--- a/DependencyInjection/Factory/LocalAdapterFactory.php
+++ b/DependencyInjection/Factory/LocalAdapterFactory.php
@@ -2,10 +2,9 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
 /**
  * Local adapter factory
@@ -19,9 +18,7 @@ class LocalAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.adapter.local')
-            : new DefinitionDecorator('knp_gaufrette.adapter.local');
+        $childDefinition = new ChildDefinition('knp_gaufrette.adapter.local');
 
         $container
             ->setDefinition($id, $childDefinition)
@@ -41,7 +38,7 @@ class LocalAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $node): void
+    public function addConfiguration(ArrayNodeDefinition $node): void
     {
         $node
             ->children()

--- a/DependencyInjection/Factory/PhpseclibSftpAdapterFactory.php
+++ b/DependencyInjection/Factory/PhpseclibSftpAdapterFactory.php
@@ -2,10 +2,9 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -18,9 +17,7 @@ class PhpseclibSftpAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.adapter.phpseclib_sftp')
-            : new DefinitionDecorator('knp_gaufrette.adapter.phpseclib_sftp');
+        $childDefinition = new ChildDefinition('knp_gaufrette.adapter.phpseclib_sftp');
 
         $container
             ->setDefinition($id, $childDefinition)
@@ -41,7 +38,7 @@ class PhpseclibSftpAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $builder): void
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         $builder
             ->children()

--- a/DependencyInjection/Factory/PhpseclibSftpAdapterFactory.php
+++ b/DependencyInjection/Factory/PhpseclibSftpAdapterFactory.php
@@ -16,7 +16,7 @@ class PhpseclibSftpAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
             ? new ChildDefinition('knp_gaufrette.adapter.phpseclib_sftp')

--- a/DependencyInjection/Factory/PhpseclibSftpAdapterFactory.php
+++ b/DependencyInjection/Factory/PhpseclibSftpAdapterFactory.php
@@ -18,7 +18,7 @@ class PhpseclibSftpAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.adapter.phpseclib_sftp')
             : new DefinitionDecorator('knp_gaufrette.adapter.phpseclib_sftp');
 

--- a/DependencyInjection/Factory/SafeLocalAdapterFactory.php
+++ b/DependencyInjection/Factory/SafeLocalAdapterFactory.php
@@ -19,7 +19,7 @@ class SafeLocalAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.adapter.safe_local')
             : new DefinitionDecorator('knp_gaufrette.adapter.safe_local');
 

--- a/DependencyInjection/Factory/SafeLocalAdapterFactory.php
+++ b/DependencyInjection/Factory/SafeLocalAdapterFactory.php
@@ -17,7 +17,7 @@ class SafeLocalAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $childDefinition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
             ? new ChildDefinition('knp_gaufrette.adapter.safe_local')

--- a/DependencyInjection/Factory/SafeLocalAdapterFactory.php
+++ b/DependencyInjection/Factory/SafeLocalAdapterFactory.php
@@ -2,10 +2,9 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
 /**
  * Safe local adapter factory
@@ -19,9 +18,7 @@ class SafeLocalAdapterFactory implements AdapterFactoryInterface
      */
     public function create(ContainerBuilder $container, string $id, array $config): void
     {
-        $childDefinition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.adapter.safe_local')
-            : new DefinitionDecorator('knp_gaufrette.adapter.safe_local');
+        $childDefinition = new ChildDefinition('knp_gaufrette.adapter.safe_local');
 
         $container
             ->setDefinition($id, $childDefinition)
@@ -41,7 +38,7 @@ class SafeLocalAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $node): void
+    public function addConfiguration(ArrayNodeDefinition $node): void
     {
         $node
             ->children()

--- a/DependencyInjection/Factory/ServiceAdapterFactory.php
+++ b/DependencyInjection/Factory/ServiceAdapterFactory.php
@@ -2,7 +2,7 @@
 
 namespace Knp\Bundle\GaufretteBundle\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -31,7 +31,7 @@ class ServiceAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function addConfiguration(NodeDefinition $builder): void
+    public function addConfiguration(ArrayNodeDefinition $builder): void
     {
         $builder
             ->children()

--- a/DependencyInjection/Factory/ServiceAdapterFactory.php
+++ b/DependencyInjection/Factory/ServiceAdapterFactory.php
@@ -15,7 +15,7 @@ class ServiceAdapterFactory implements AdapterFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config): void
+    public function create(ContainerBuilder $container, string $id, array $config): void
     {
         $container->setAlias($id, $config['id']);
     }

--- a/DependencyInjection/KnpGaufretteExtension.php
+++ b/DependencyInjection/KnpGaufretteExtension.php
@@ -96,7 +96,7 @@ class KnpGaufretteExtension extends Extension
         $adapter = $adapters[$config['adapter']];
         $id      = sprintf('gaufrette.%s_filesystem', $name);
 
-        $definition = class_exists('\Symfony\Component\DependencyInjection\ChildDefinition')
+        $definition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
             ? new ChildDefinition('knp_gaufrette.filesystem')
             : new DefinitionDecorator('knp_gaufrette.filesystem');
 

--- a/DependencyInjection/KnpGaufretteExtension.php
+++ b/DependencyInjection/KnpGaufretteExtension.php
@@ -96,9 +96,7 @@ class KnpGaufretteExtension extends Extension
         $adapter = $adapters[$config['adapter']];
         $id      = sprintf('gaufrette.%s_filesystem', $name);
 
-        $definition = class_exists(\Symfony\Component\DependencyInjection\ChildDefinition::class)
-            ? new ChildDefinition('knp_gaufrette.filesystem')
-            : new DefinitionDecorator('knp_gaufrette.filesystem');
+        $definition = new ChildDefinition('knp_gaufrette.filesystem');
 
         $container
             ->setDefinition($id, $definition)

--- a/DependencyInjection/KnpGaufretteExtension.php
+++ b/DependencyInjection/KnpGaufretteExtension.php
@@ -7,7 +7,6 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
@@ -19,7 +18,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class KnpGaufretteExtension extends Extension
 {
-    private $factories;
+    private ?array $factories = null;
 
     /**
      * Loads the extension
@@ -36,13 +35,13 @@ class KnpGaufretteExtension extends Extension
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('gaufrette.php');
 
-        $adapters = array();
+        $adapters = [];
 
         foreach ($config['adapters'] as $name => $adapter) {
             $adapters[$name] = $this->createAdapter($name, $adapter, $container, $this->factories);
         }
 
-        $map = array();
+        $map = [];
         foreach ($config['filesystems'] as $name => $filesystem) {
             $map[$name] = $this->createFilesystem($name, $filesystem, $container, $adapters);
         }

--- a/DependencyInjection/MainConfiguration.php
+++ b/DependencyInjection/MainConfiguration.php
@@ -13,16 +13,13 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class MainConfiguration implements ConfigurationInterface
 {
-    private $factories;
-
     /**
      * Constructor
      *
      * @param  array $factories
      */
-    public function __construct(array $factories)
+    public function __construct(private array $factories)
     {
-        $this->factories = $factories;
     }
 
     /**
@@ -94,12 +91,8 @@ class MainConfiguration implements ConfigurationInterface
                         ->scalarNode('protocol')->defaultValue('gaufrette')->treatNullLike('gaufrette')->end()
                         ->arrayNode('filesystems')
                             ->beforeNormalization()
-                                ->ifTrue(function ($array) {
-                                    return !(bool)count(array_filter(array_keys($array), 'is_string'));
-                                })
-                                ->then(function ($array) {
-                                    return array_combine($array, $array);
-                                })
+                                ->ifTrue(fn($array) => !(bool)count(array_filter(array_keys($array), 'is_string')))
+                                ->then(fn($array) => array_combine($array, $array))
                             ->end()
                             ->useAttributeAsKey('key')
                             ->prototype('scalar')

--- a/FilesystemMap.php
+++ b/FilesystemMap.php
@@ -16,7 +16,7 @@ class FilesystemMap implements \IteratorAggregate, FilesystemMapInterface
      *
      * @var array
      */
-    protected $maps;
+    protected array $maps;
 
     /**
      * Instantiates a new filesystem map.

--- a/FilesystemMap.php
+++ b/FilesystemMap.php
@@ -12,20 +12,17 @@ use Gaufrette\FilesystemMapInterface;
 class FilesystemMap implements \IteratorAggregate, FilesystemMapInterface
 {
     /**
-     * Map of filesystems indexed by their name.
-     *
-     * @var array
-     */
-    protected array $maps;
-
-    /**
      * Instantiates a new filesystem map.
      *
      * @param array $maps
      */
-    public function __construct(array $maps)
+    public function __construct(
+        /**
+         * Map of filesystems indexed by their name.
+         */
+        protected array $maps
+    )
     {
-        $this->maps = $maps;
     }
 
     /**

--- a/Resources/config/gaufrette.php
+++ b/Resources/config/gaufrette.php
@@ -34,14 +34,14 @@ return function (ContainerConfigurator $configurator) {
     $services
         ->set('knp_gaufrette.adapter.in_memory', InMemory::class)
         ->abstract()
-        ->public(false)
+        ->private()
         ->arg(0, null) // Files
     ;
 
     $services
         ->set('knp_gaufrette.adapter.local', Local::class)
         ->abstract()
-        ->public(false)
+        ->private()
         ->arg(0, null)  // Directory
         ->arg(1, null)  // Create
     ;
@@ -49,7 +49,7 @@ return function (ContainerConfigurator $configurator) {
     $services
         ->set('knp_gaufrette.adapter.safe_local', SafeLocal::class)
         ->abstract()
-        ->public(false)
+        ->private()
         ->arg(0, null)  // Directory
         ->arg(1, null)  // Create
     ;
@@ -57,22 +57,22 @@ return function (ContainerConfigurator $configurator) {
     $services
         ->set('knp_gaufrette.adapter.async_aws_s3', AsyncAwsS3::class)
         ->abstract()
-        ->public(false);
+        ->private();
 
     $services
         ->set('knp_gaufrette.adapter.aws_s3', AwsS3::class)
         ->abstract()
-        ->public(false);
+        ->private();
 
     $services
         ->set('knp_gaufrette.adapter.doctrine_dbal', DoctrineDbal::class)
         ->abstract()
-        ->public(false);
+        ->private();
 
     $services
         ->set('knp_gaufrette.adapter.opencloud', OpenCloud::class)
         ->abstract()
-        ->public(false)
+        ->private()
         ->arg(0, null)  // ObjectStore
         ->arg(1, null)  // Container name
         ->arg(2, null)  // Create container
@@ -82,27 +82,27 @@ return function (ContainerConfigurator $configurator) {
     $services
         ->set('knp_gaufrette.adapter.azure_blob_storage', AzureBlobStorage::class)
         ->abstract()
-        ->public(false);
+        ->private();
 
     $services
         ->set('knp_gaufrette.adapter.google_cloud_storage', GoogleCloudStorage::class)
         ->abstract()
-        ->public(false);
+        ->private();
 
     $services
         ->set('knp_gaufrette.adapter.gridfs', GridFS::class)
         ->abstract()
-        ->public(false);
+        ->private();
 
     $services
         ->set('knp_gaufrette.adapter.ftp', Ftp::class)
         ->abstract()
-        ->public(false);
+        ->private();
 
     $services
         ->set('knp_gaufrette.adapter.phpseclib_sftp', PhpseclibSftp::class)
         ->abstract()
-        ->public(false);
+        ->private();
 
     $services
         ->set('knp_gaufrette.filesystem_map', '%knp_gaufrette.filesystem_map.class%')
@@ -112,7 +112,7 @@ return function (ContainerConfigurator $configurator) {
 
     $services
         ->alias(FilesystemMap::class, 'knp_gaufrette.filesystem_map')
-        ->public(false);
+        ->private();
 
     $services
         ->set('knp_gaufrette.command.filesystem_keys', FilesystemKeysCommand::class)

--- a/Tests/FilesystemMapTest.php
+++ b/Tests/FilesystemMapTest.php
@@ -11,7 +11,7 @@ class FilesystemMapTest extends TestCase
 
     public function setUp(): void
     {
-        $this->filesystemMap = new FilesystemMap(array('amazon_fs' => $this->getFilesystem(), 'local_fs' => $this->getFilesystem()));
+        $this->filesystemMap = new FilesystemMap(['amazon_fs' => $this->getFilesystem(), 'local_fs' => $this->getFilesystem()]);
     }
 
     /**
@@ -19,12 +19,12 @@ class FilesystemMapTest extends TestCase
      */
     public function shouldGetFilesystemByKey()
     {
-        if(class_exists('Gaufrette\FilesystemInterface')) {
-            $this->assertInstanceOf('Gaufrette\FilesystemInterface', $this->filesystemMap->get('amazon_fs'), 'should get filesystem object by key');
-            $this->assertInstanceOf('Gaufrette\FilesystemInterface', $this->filesystemMap->get('local_fs'), 'should get filesystem object by key');
+        if(class_exists(\Gaufrette\FilesystemInterface::class)) {
+            $this->assertInstanceOf(\Gaufrette\FilesystemInterface::class, $this->filesystemMap->get('amazon_fs'), 'should get filesystem object by key');
+            $this->assertInstanceOf(\Gaufrette\FilesystemInterface::class, $this->filesystemMap->get('local_fs'), 'should get filesystem object by key');
         } else {
-            $this->assertInstanceOf('Gaufrette\Filesystem', $this->filesystemMap->get('amazon_fs'), 'should get filesystem object by key');
-            $this->assertInstanceOf('Gaufrette\Filesystem', $this->filesystemMap->get('local_fs'), 'should get filesystem object by key');
+            $this->assertInstanceOf(\Gaufrette\Filesystem::class, $this->filesystemMap->get('amazon_fs'), 'should get filesystem object by key');
+            $this->assertInstanceOf(\Gaufrette\Filesystem::class, $this->filesystemMap->get('local_fs'), 'should get filesystem object by key');
         }
 
     }
@@ -44,7 +44,7 @@ class FilesystemMapTest extends TestCase
      */
     private function getFilesystem()
     {
-        return $this->getMockBuilder('Gaufrette\Filesystem')
+        return $this->getMockBuilder(\Gaufrette\Filesystem::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/Tests/Functional/ConfigurationTest.php
+++ b/Tests/Functional/ConfigurationTest.php
@@ -39,7 +39,7 @@ class ConfigurationTest extends TestCase
      */
     public function shouldAllowForFilesystemAlias()
     {
-        $this->assertInstanceOf('Gaufrette\Filesystem', $this->kernel->getContainer()->get('foo_filesystem'));
+        $this->assertInstanceOf(\Gaufrette\Filesystem::class, $this->kernel->getContainer()->get('foo_filesystem'));
     }
 
     /**
@@ -52,7 +52,7 @@ class ConfigurationTest extends TestCase
         $kernel->boot();
 
         $container = $kernel->getContainer();
-        $this->assertInstanceOf('Gaufrette\Filesystem', $container->get('foo_filesystem'));
+        $this->assertInstanceOf(\Gaufrette\Filesystem::class, $container->get('foo_filesystem'));
     }
 
     /**
@@ -61,7 +61,7 @@ class ConfigurationTest extends TestCase
      */
     public function shouldAllowAccessToAllPublicServices()
     {
-        $this->assertInstanceOf('Knp\Bundle\GaufretteBundle\FilesystemMap', $this->kernel->getContainer()->get('knp_gaufrette.filesystem_map'));
+        $this->assertInstanceOf(\Knp\Bundle\GaufretteBundle\FilesystemMap::class, $this->kernel->getContainer()->get('knp_gaufrette.filesystem_map'));
     }
 
     /**
@@ -69,7 +69,7 @@ class ConfigurationTest extends TestCase
      */
     public function shouldAllowAccessToFilesystemThoughFilesystemMap()
     {
-        $this->assertInstanceOf('Gaufrette\Filesystem', $this->kernel->getContainer()->get('knp_gaufrette.filesystem_map')->get('foo'));
+        $this->assertInstanceOf(\Gaufrette\Filesystem::class, $this->kernel->getContainer()->get('knp_gaufrette.filesystem_map')->get('foo'));
     }
 
     /**
@@ -78,7 +78,7 @@ class ConfigurationTest extends TestCase
      */
     public function shouldAllowAccessToLocalFilesystem()
     {
-        $this->assertInstanceOf('Gaufrette\Adapter\Local', $this->kernel->getContainer()->get('foo_filesystem')->getAdapter());
+        $this->assertInstanceOf(\Gaufrette\Adapter\Local::class, $this->kernel->getContainer()->get('foo_filesystem')->getAdapter());
     }
 
     /**
@@ -87,7 +87,7 @@ class ConfigurationTest extends TestCase
      */
     public function shouldAllowAccessToFtpFilesystem()
     {
-        $this->assertInstanceOf('Gaufrette\Adapter\Ftp', $this->kernel->getContainer()->get('ftp_filesystem')->getAdapter());
+        $this->assertInstanceOf(\Gaufrette\Adapter\Ftp::class, $this->kernel->getContainer()->get('ftp_filesystem')->getAdapter());
     }
 
     /**
@@ -114,10 +114,7 @@ class ConfigurationTest extends TestCase
 
         $wrapperFsMap = StreamWrapper::getFilesystemMap();
 
-        $expectedDomains = array(
-            'foo',
-            'ftp',
-        );
+        $expectedDomains = ['foo', 'ftp'];
 
         foreach ($expectedDomains as $eachExpectedDomain) {
             $this->assertTrue($wrapperFsMap->has($eachExpectedDomain));
@@ -149,7 +146,7 @@ class ConfigurationTest extends TestCase
         $container = $kernel->getContainer();
         $fileSystems = $container->getParameter('knp_gaufrette.stream_wrapper.filesystems');
 
-        $this->assertEquals(array('pictures' => 'foo', 'text' => 'ftp'), $fileSystems);
+        $this->assertEquals(['pictures' => 'foo', 'text' => 'ftp'], $fileSystems);
 
         $wrapperFsMap = StreamWrapper::getFilesystemMap();
 
@@ -171,7 +168,7 @@ class ConfigurationTest extends TestCase
 
         $this->assertTrue($container->hasParameter('knp_gaufrette.stream_wrapper.protocol'));
         $this->assertEquals('tada', $container->getParameter('knp_gaufrette.stream_wrapper.protocol'));
-        $this->assertEquals(array('ftp' => 'ftp'), $fileSystems);
+        $this->assertEquals(['ftp' => 'ftp'], $fileSystems);
 
         $wrapperFsMap = StreamWrapper::getFilesystemMap();
 

--- a/Tests/Functional/TestKernel.php
+++ b/Tests/Functional/TestKernel.php
@@ -14,9 +14,7 @@ class TestKernel extends Kernel
 
     public function registerBundles(): iterable
     {
-        return array(
-            new \Knp\Bundle\GaufretteBundle\KnpGaufretteBundle(),
-        );
+        return [new \Knp\Bundle\GaufretteBundle\KnpGaufretteBundle()];
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader): void

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/http-kernel": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^7.0|^8.0",
+        "symfony/phpunit-bridge": "^6.0|^7.0|^8.0",
         "symfony/console": "^5.0|^6.0|^7.0|^8.0",
         "symfony/filesystem": "^5.0|^6.0|^7.0|^8.0",
         "symfony/yaml": "^5.0|^6.0|^7.0|^8.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- http://phpunit.de/manual/4.1/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true">
   <coverage>
     <include>
       <directory suffix=".php">.</directory>


### PR DESCRIPTION
> [!WARNING]
> BREAKING CHANGE: AdapterFactoryInterface::create() now declares string $id, and
addConfiguration() now type-hints its parameter as ArrayNodeDefinition instead of the more
generic NodeDefinition. Any class implementing this interface must update both method
signatures accordingly.

> [!WARNING]
> BREAKING CHANGE: the gaufrette:filesystem:keys command no longer accepts an optional glob
argument to filter results — the underlying Gaufrette\Glob class is no longer used.

- Expand symfony/phpunit-bridge constraint to ^6.0|^7.0|^8.0 so PHP 8.0/8.1 can resolve bridge 6.x
(bridge 7.x requires PHP 8.2)
- Add string type to AdapterFactoryInterface::create() $id param and all 12 concrete factory
implementations; change addConfiguration()'s parameter type from NodeDefinition to
ArrayNodeDefinition across the interface and every factory
- Remove the glob argument and Gaufrette\Glob usage from FilesystemKeysCommand
- Promote constructor properties in FilesystemKeysCommand, MainConfiguration, and
FilesystemMap; type KnpGaufretteExtension::$factories
- Change adapter service definitions in Resources/config/gaufrette.php from ->public(false) to
->private()
- Remove dead DefinitionDecorator import/fallback from KnpGaufretteExtension and all factories
(now unconditionally use ChildDefinition)
- Replace array() literals with [] and closures with arrow functions where applicable
- Update test assertions to use ::class instead of class-name strings
- CI: add a prefer-lowest/prefer-stable dependency matrix dimension per PHP version, and add a
PHP syntax lint step (php -l)
- Update phpunit.xml.dist schema reference to PHPUnit 10.5